### PR TITLE
Use typeof to check if window is defined, fixes #29

### DIFF
--- a/jsnlog.js
+++ b/jsnlog.js
@@ -793,7 +793,7 @@ if (typeof __jsnlog_configure == 'function') {
 }
 // Create onerror handler to log uncaught exceptions to the server side log, but only if there 
 // is no such handler already.
-if (window && !window.onerror) {
+if (typeof window !== 'undefined' && !window.onerror) {
     window.onerror = function (errorMsg, url, lineNumber, column, errorObj) {
         // Send object with all data to server side log, using severity fatal, 
         // from logger "onerrorLogger"

--- a/jsnlog.ts
+++ b/jsnlog.ts
@@ -985,7 +985,7 @@ if (typeof __jsnlog_configure == 'function') { __jsnlog_configure(JL); }
 // Create onerror handler to log uncaught exceptions to the server side log, but only if there 
 // is no such handler already.
 
-if (window && !window.onerror) {
+if (typeof window !== 'undefined' && !window.onerror) {
     window.onerror = function (errorMsg, url, lineNumber, column, errorObj) {
         // Send object with all data to server side log, using severity fatal, 
         // from logger "onerrorLogger"


### PR DESCRIPTION
Uses typeof to check if `window` defined as current check raises ReferenceError under Node.js.