### PR TITLE
updated definition file to match actual beforesend parameters.

### DIFF
--- a/Definitions/jl.d.ts
+++ b/Definitions/jl.d.ts
@@ -57,7 +57,7 @@ declare namespace JL {
 
 	interface JSNLogAjaxAppenderOptions extends JSNLogAppenderOptions {
 		url?: string;
-		beforeSend?: (xhr: XMLHttpRequest) => void;
+		beforeSend?: (xhr: XMLHttpRequest, json: any) => void;
 	}
 
 	interface JSNLogLogger {

--- a/Definitions/jsnlog_interfaces.d.ts
+++ b/Definitions/jsnlog_interfaces.d.ts
@@ -47,7 +47,7 @@ declare namespace JL {
 
 	interface JSNLogAjaxAppenderOptions extends JSNLogAppenderOptions {
 		url?: string;
-		beforeSend?: (xhr: XMLHttpRequest) => void;
+		beforeSend?: (xhr: XMLHttpRequest, json: any) => void;
 	}
 
 	interface JSNLogLogger {


### PR DESCRIPTION
The typescript definition files are missing the json parameter for the beforeSend function in ajaxAppender which throws compilation errors when developing in typescript. I added the json parameter which fixed this issue.