### PR TITLE
#47: Allow onunhandledrejection pass error to console

### DIFF
--- a/jsnlog.ts
+++ b/jsnlog.ts
@@ -1058,8 +1058,6 @@ if (typeof window !== 'undefined' && !(<any>window).onunhandledrejection) {
             "msg": "unhandledrejection",
             "errorMsg": event.reason ? event.reason.message : null
         }, event.reason);
-        // Tell browser to run its own error handler as well   
-        return false;
     };
 }
 


### PR DESCRIPTION
Removed inappropriate return from onunhandledrejection which stops to send errors to console