### PR TITLE
Disallow logs, if global logging config is disabled

### DIFF
--- a/jsnlog.js
+++ b/jsnlog.js
@@ -437,7 +437,7 @@ function JL(loggerName) {
             // increase the timeout for the first item.
             //
             // To determine if this is the first item, look at the timer variable.
-            // Do not look at the buffer lenght, because we also put items in the buffer
+            // Do not look at the buffer length, because we also put items in the buffer
             // via a concat (bypassing this function).
             //
             // The setTimer method only sets the timer if it is not already running.
@@ -633,6 +633,10 @@ function JL(loggerName) {
             // is only called when it tries to log something, so the requestId has to be 
             // determined right at the start of request processing.
             try {
+                // Do not send logs, if JL.enabled is set to false
+                if (allow(this)) {
+                    return;
+                }
                 // If a request is in progress, abort it.
                 // Otherwise, it may call the success callback, which will be very confusing.
                 // It may also stop the inflight request from resulting in a log at the server.
@@ -740,6 +744,10 @@ function JL(loggerName) {
         };
         ConsoleAppender.prototype.sendLogItemsConsole = function (logItems, successCallback) {
             try {
+                // Do not send logs, if JL.enabled is set to false
+                if (allow(this)) {
+                    return;
+                }
                 if (!JL._console) {
                     return;
                 }

--- a/jsnlog.js
+++ b/jsnlog.js
@@ -634,7 +634,7 @@ function JL(loggerName) {
             // determined right at the start of request processing.
             try {
                 // Do not send logs, if JL.enabled is set to false
-                if (allow(this)) {
+                if (!allow(this)) {
                     return;
                 }
                 // If a request is in progress, abort it.
@@ -745,7 +745,7 @@ function JL(loggerName) {
         ConsoleAppender.prototype.sendLogItemsConsole = function (logItems, successCallback) {
             try {
                 // Do not send logs, if JL.enabled is set to false
-                if (allow(this)) {
+                if (!allow(this)) {
                     return;
                 }
                 if (!JL._console) {

--- a/jsnlog.ts
+++ b/jsnlog.ts
@@ -507,7 +507,7 @@ module JL
             // increase the timeout for the first item.
             //
             // To determine if this is the first item, look at the timer variable.
-            // Do not look at the buffer lenght, because we also put items in the buffer
+            // Do not look at the buffer length, because we also put items in the buffer
             // via a concat (bypassing this function).
             //
             // The setTimer method only sets the timer if it is not already running.
@@ -742,6 +742,9 @@ module JL
             // determined right at the start of request processing.
             try
             {
+                // Do not send logs, if JL.enabled is set to false
+                if (allow(this)) { return; }
+
                 // If a request is in progress, abort it.
                 // Otherwise, it may call the success callback, which will be very confusing.
                 // It may also stop the inflight request from resulting in a log at the server.
@@ -884,6 +887,9 @@ module JL
         {
             try
             {
+                // Do not send logs, if JL.enabled is set to false
+                if (allow(this)) { return; }
+
                 if (!JL._console) { return; }
 
                 var i;

--- a/jsnlog.ts
+++ b/jsnlog.ts
@@ -743,7 +743,7 @@ module JL
             try
             {
                 // Do not send logs, if JL.enabled is set to false
-                if (allow(this)) { return; }
+                if (!allow(this)) { return; }
 
                 // If a request is in progress, abort it.
                 // Otherwise, it may call the success callback, which will be very confusing.
@@ -888,7 +888,7 @@ module JL
             try
             {
                 // Do not send logs, if JL.enabled is set to false
-                if (allow(this)) { return; }
+                if (!allow(this)) { return; }
 
                 if (!JL._console) { return; }
 


### PR DESCRIPTION
The logs will not be sent to server nor to console if global logging is disabled. This fixes problems with already added logs to the appenders that should not be sent.