### PR TITLE
Add json parameter to defaultBeforeSend

### DIFF
--- a/Definitions/jl.d.ts
+++ b/Definitions/jl.d.ts
@@ -31,7 +31,7 @@ declare namespace JL {
 		defaultAjaxUrl?: string;
 		clientIP?: string;
 		requestId?: string;
-		defaultBeforeSend?: (xhr: XMLHttpRequest) => void;
+		defaultBeforeSend?: (xhr: XMLHttpRequest, json?: any) => void;
 		serialize?: (object: any) => string;
 	}
 


### PR DESCRIPTION
The function provided to beforeSend receives 2 parameters, xhr and json. Added the json parameter as optional to avoid breaking existing code. http://js.jsnlog.com/Documentation/HowTo/AddingRequestHeaders